### PR TITLE
Fix MockK library name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **Image loading:** Coil.
 - **Parsing:** Gson.
 - **Testing Framework:**
-  - MocckK 
+  - MockK 
   - Espresso
   - Google Truth
 


### PR DESCRIPTION
## Summary
- fix typo of MockK library name in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2087a2608321a4e3cc59eaf58136