### PR TITLE
Handle network exceptions before generic catch

### DIFF
--- a/app/src/main/java/com/samad_talukder/mvvmcompose/utils/ApiState.kt
+++ b/app/src/main/java/com/samad_talukder/mvvmcompose/utils/ApiState.kt
@@ -39,12 +39,12 @@ suspend fun <T> safeApiCall(
         ApiState.Error(errorMessage, errorCode)
     }
 
-} catch (ex: Exception) {
-    apiError(ex.message ?: ex.toString())
-} catch (io: IOException) {
-    apiError(io.message ?: "No Internet")
 } catch (sc: SocketTimeoutException) {
     apiError(sc.message ?: "Timeout")
+} catch (io: IOException) {
+    apiError(io.message ?: "No Internet")
+} catch (ex: Exception) {
+    apiError(ex.message ?: ex.toString())
 }
 
 fun <T> apiError(errorMessage: String): ApiState<T> = ApiState.Error(errorMessage)


### PR DESCRIPTION
## Summary
- Handle `SocketTimeoutException` and `IOException` before generic `Exception` to avoid shadowing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab215d2d4c83219993a15e7c240f5b