### PR TITLE
test: add GithubUserDetailUseCase tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,8 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/test/java/com/samad_talukder/mvvmcompose/domain/usecase/GithubUserDetailUseCaseTest.kt
+++ b/app/src/test/java/com/samad_talukder/mvvmcompose/domain/usecase/GithubUserDetailUseCaseTest.kt
@@ -1,0 +1,123 @@
+package com.samad_talukder.mvvmcompose.domain.usecase
+
+import com.samad_talukder.mvvmcompose.data.remote.model.GitHubUserDetailResponse
+import com.samad_talukder.mvvmcompose.data.remote.model.mapper.GithubUserDetailsMapper
+import com.samad_talukder.mvvmcompose.domain.models.GitHubUserEntity
+import com.samad_talukder.mvvmcompose.domain.repository.GithubUserDetailRepository
+import com.samad_talukder.mvvmcompose.utils.ApiState
+import com.samad_talukder.mvvmcompose.utils.UiState
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GithubUserDetailUseCaseTest {
+
+    private lateinit var repository: GithubUserDetailRepository
+    private lateinit var mapper: GithubUserDetailsMapper
+    private lateinit var useCase: GithubUserDetailUseCase
+
+    @Before
+    fun setup() {
+        repository = mockk()
+        mapper = mockk()
+        useCase = GithubUserDetailUseCase(repository, mapper)
+    }
+
+    @Test
+    fun `ApiState Success from repository emits UiState Success with mapped entity`() = runTest {
+        val username = "john"
+        val response = GitHubUserDetailResponse(
+            avatar_url = "avatar",
+            bio = "bio",
+            blog = "blog",
+            company = "company",
+            created_at = "2025-01-01",
+            email = "",
+            events_url = "",
+            followers = 10,
+            followers_url = "",
+            following = 5,
+            following_url = "",
+            gists_url = "",
+            gravatar_id = "",
+            hireable = false,
+            html_url = "",
+            id = 1,
+            location = "Earth",
+            login = username,
+            name = "John",
+            node_id = "",
+            organizations_url = "",
+            public_gists = 0,
+            public_repos = 3,
+            received_events_url = "",
+            repos_url = "",
+            site_admin = false,
+            starred_url = "",
+            subscriptions_url = "",
+            twitter_username = "",
+            type = "",
+            updated_at = "",
+            url = "",
+            user_view_type = ""
+        )
+        val entity = GitHubUserEntity(
+            username = username,
+            avatarUrl = "avatar",
+            name = "John",
+            company = "company",
+            blog = "blog",
+            location = "Earth",
+            bio = "bio",
+            publicRepos = 3,
+            followers = 10,
+            following = 5,
+            joinedDate = "2025-01-01"
+        )
+
+        coEvery { repository.getUserDetails(username) } returns flowOf(ApiState.Success(response))
+        every { mapper.mapFrom(response) } returns entity
+
+        val result = useCase.invoke(username).first()
+
+        assertEquals(UiState.Success(entity), result)
+        coVerify(exactly = 1) { repository.getUserDetails(username) }
+        verify(exactly = 1) { mapper.mapFrom(response) }
+    }
+
+    @Test
+    fun `ApiState Error with not found message becomes UiState Error with friendly message`() = runTest {
+        val username = "missing"
+        val errorMessage = "User not found"
+        coEvery { repository.getUserDetails(username) } returns flowOf(ApiState.Error(errorMessage))
+
+        val result = useCase.invoke(username).first()
+
+        assertEquals(
+            UiState.Error("Resources not found. Please check the spelling and try again."),
+            result
+        )
+    }
+
+    @Test
+    fun `ApiState Error with other message propagates to UiState Error`() = runTest {
+        val username = "other"
+        val errorMessage = "Internal server error"
+        coEvery { repository.getUserDetails(username) } returns flowOf(ApiState.Error(errorMessage))
+
+        val result = useCase.invoke(username).first()
+
+        assertEquals(UiState.Error(errorMessage), result)
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ coil = "2.6.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+mockk = "1.13.11"
 
 [libraries]
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
@@ -70,6 +71,8 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- add unit tests for GithubUserDetailUseCase
- wire up mockk and coroutines-test libraries for unit testing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab241d37b8832185f13e11a5534088