### PR TITLE
test: add GitHub user detail ViewModel tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,8 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/test/java/com/samad_talukder/mvvmcompose/ui/viewmodel/GitHubUserDetailViewModelTest.kt
+++ b/app/src/test/java/com/samad_talukder/mvvmcompose/ui/viewmodel/GitHubUserDetailViewModelTest.kt
@@ -1,0 +1,101 @@
+package com.samad_talukder.mvvmcompose.ui.viewmodel
+
+import com.samad_talukder.mvvmcompose.domain.models.GitHubUserEntity
+import com.samad_talukder.mvvmcompose.domain.usecase.GithubUserDetailUseCase
+import com.samad_talukder.mvvmcompose.utils.UiState
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GitHubUserDetailViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val userDetailUseCase: GithubUserDetailUseCase = mockk()
+
+    @Test
+    fun `userState emits Loading then Success`() = runTest(mainDispatcherRule.dispatcher) {
+        val username = "octocat"
+        val entity = GitHubUserEntity(
+            username = username,
+            avatarUrl = "avatar",
+            name = "Octo Cat",
+            company = null,
+            blog = null,
+            location = null,
+            bio = null,
+            publicRepos = 1,
+            followers = 2,
+            following = 3,
+            joinedDate = "2024-01-01"
+        )
+
+        coEvery { userDetailUseCase.invoke(username) } returns flowOf(UiState.Success(entity))
+
+        val viewModel = GitHubUserDetailViewModel(userDetailUseCase)
+
+        val emissions = mutableListOf<UiState<GitHubUserEntity>>()
+        val job = launch { viewModel.userState.take(2).toList(emissions) }
+
+        viewModel.loadUserDetailData(username)
+        advanceUntilIdle()
+
+        assertEquals(UiState.Loading, emissions[0])
+        assertEquals(UiState.Success(entity), emissions[1])
+
+        job.cancel()
+    }
+
+    @Test
+    fun `userState emits Loading then Error`() = runTest(mainDispatcherRule.dispatcher) {
+        val username = "octocat"
+        val message = "Network Error"
+
+        coEvery { userDetailUseCase.invoke(username) } returns flowOf(UiState.Error(message))
+
+        val viewModel = GitHubUserDetailViewModel(userDetailUseCase)
+
+        val emissions = mutableListOf<UiState<GitHubUserEntity>>()
+        val job = launch { viewModel.userState.take(2).toList(emissions) }
+
+        viewModel.loadUserDetailData(username)
+        advanceUntilIdle()
+
+        assertEquals(UiState.Loading, emissions[0])
+        assertEquals(UiState.Error(message), emissions[1])
+
+        job.cancel()
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,8 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+mockk = { group = "io.mockk", name = "mockk", version = "1.13.10" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- add unit tests for `GitHubUserDetailViewModel`
- include `MainDispatcherRule` and coroutines test utilities
- add test dependencies for MockK and coroutines-test

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab24180af08321aa4d2fa2b0e10b9d